### PR TITLE
Improved merging

### DIFF
--- a/test/test.rb
+++ b/test/test.rb
@@ -195,6 +195,22 @@ class TestHistk < Test::Unit::TestCase
     end
   end
 
+  def test_empty_merge
+    assert_equal(0, @r.call(%w(histk.mergestore a b c d e f g h i)))
+  end
+
+  def test_sparse_sources_merge
+    @r.call(['histk.add', 'f', 1])
+    assert_equal(1, @r.call(%w(histk.mergestore a b c d e f g h i)))
+  end
+
+  def test_sparse_target_merge
+    @r.call(['histk.add', 'a', 1])
+    @r.call(['histk.add', 'a', 2])
+    @r.call(['histk.add', 'a', 2])
+    assert_equal(3, @r.call(%w(histk.mergestore a b c d e f g h i)))
+  end
+
   def test_merge
     (1..100).each { |i| @r.call(['histk.add', 's', i]) }
     (101..200).each { |i| @r.call(['histk.add', 't', i]) }
@@ -202,6 +218,23 @@ class TestHistk < Test::Unit::TestCase
     assert_equal(200, @r.call(%w(histk.mergestore v s t)))
     assert_equal(300, @r.call(%w(histk.mergestore w s t u)))
     error = 1.5  # Arbitrary
+    x = @r.call(%w(histk.quantile s 0.50)).to_f
+    y = @r.call(%w(histk.quantile v 0.25)).to_f
+    z = @r.call(%w(histk.quantile w 0.17)).to_f
+    assert_operator((x - y).abs, :<, error)
+    assert_operator((y - z).abs, :<, error)
+  end
+
+  def test_merge_small
+    %w(s t u v w).each { |hist| @r.call(['histk.resize', hist, 4]) }
+    (1..100).each { |i| @r.call(['histk.add', 's', i]) }
+    (101..200).each { |i| @r.call(['histk.add', 't', i]) }
+    (201..300).each { |i| @r.call(['histk.add', 'u', i]) }
+    assert_equal(200, @r.call(%w(histk.mergestore v s t)))
+    assert_equal(300, @r.call(%w(histk.mergestore w s t u)))
+    assert_equal(600, @r.call(%w(histk.mergestore w s t u)))
+    assert_equal(900, @r.call(%w(histk.mergestore w s t u)))
+    error = 2.5  # Arbitrary
     x = @r.call(%w(histk.quantile s 0.50)).to_f
     y = @r.call(%w(histk.quantile v 0.25)).to_f
     z = @r.call(%w(histk.quantile w 0.17)).to_f


### PR DESCRIPTION
When merging sketches together, put all centroids from all sketches in an array and repeatedly merge the two closest centroids until the number of centroids is less than or equal to the max number of centroids in the target sketch.
